### PR TITLE
字体路径问题导致无法获取角色id列表，修改使用完整字体路径

### DIFF
--- a/create_img.py
+++ b/create_img.py
@@ -1,5 +1,6 @@
 import io
 import base64
+import os
 from pathlib import Path
 from PIL import Image, ImageDraw, ImageFont
 
@@ -49,7 +50,8 @@ def line_break(line):
 def image_draw(msg):
     global LINE_CHAR_COUNT_MAX
     output_str = line_break(msg)
-    d_font = ImageFont.truetype('./SIMYOU.ttf', CHAR_SIZE)
+    fontpath = os.path.dirname(os.path.realpath(__file__))+'/SIMYOU.ttf'
+    d_font = ImageFont.truetype(fontpath, CHAR_SIZE)
     lines = output_str.count('\n')  # 计算行数
 
     image = Image.new(mode= "RGB", size= (LINE_CHAR_COUNT_MAX*CHAR_SIZE // 2+84, CHAR_SIZE_h*lines+84), color=(255,252,245))


### PR DESCRIPTION
```
[2022-10-21 00:23:41,505 nonebot] INFO: Self: xxxxxxxxxx, Message -1441765512 from xxxxxxxx@[群:xxxxxxxx]: '角色id列表'
[2022-10-21 00:23:41,506 角色语音模仿] INFO: Message -1441765512 triggered speaker_list.
[2022-10-21 00:23:41,508 角色语音模仿] ERROR: <class 'OSError'> occured when speaker_list handling message -1441765512.
[2022-10-21 00:23:41,508 角色语音模仿] ERROR: cannot open resource
Traceback (most recent call last):
  File "/root/xcwbot/HoshinoBot/hoshino/msghandler.py", line 21, in handle_message
    await service_func.func(bot, event)
  File "/root/xcwbot/HoshinoBot/hoshino/service.py", line 224, in wrapper
    return await func(bot, event)
  File "/root/xcwbot/HoshinoBot/hoshino/modules/youzi_voice/__init__.py", line 231, in speaker_list
    img = image_draw(speaker_id)
  File "/root/xcwbot/HoshinoBot/hoshino/modules/youzi_voice/create_img.py", line 52, in image_draw
    d_font = ImageFont.truetype('./SIMYOU.ttf', CHAR_SIZE)
  File "/usr/local/python3/lib/python3.10/site-packages/PIL/ImageFont.py", line 878, in truetype
    return freetype(font)
  File "/usr/local/python3/lib/python3.10/site-packages/PIL/ImageFont.py", line 875, in freetype
    return FreeTypeFont(font, size, index, encoding, layout_engine)
  File "/usr/local/python3/lib/python3.10/site-packages/PIL/ImageFont.py", line 226, in __init__
    self.font = core.getfont(
OSError: cannot open resource
```
经测试 Linux 和 Windows 下均有此问题，找不到字体无法生成图片，用完整的路径就可以。
版本信息：
```
Pillow=9.2
Python 3.10.7 (main, Sep 13 2022, 23:05:47) [GCC 4.8.5 20150623 (Red Hat 4.8.5-44)] on linux
```